### PR TITLE
Add support for Cloud Workstations - Workstations

### DIFF
--- a/mmv1/products/cloudworkstations/api.yaml
+++ b/mmv1/products/cloudworkstations/api.yaml
@@ -419,4 +419,104 @@ objects:
               description: |
                 A list of messages that carry the details.   
 
+  - !ruby/object:Api::Resource
+    name: 'Workstations'
+    base_url: projects/{{project}}/locations/{{location}}/workstationClusters/{{workstation_cluster_id}}/workstationConfigs/{{workstation_config_id}}/workstations
+    create_url: projects/{{project}}/locations/{{location}}/workstationClusters/{{workstation_cluster_id}/workstationConfigs/{{workstation_config_id}}/workstations?workstationId={{name}}
+    update_verb: :PATCH
+    description: |
+      A single instance of a developer workstation with its own persistent storage.
+    references: !ruby/object:Api::Resource::ReferenceLinks
+      api: 'https://cloud.google.com/workstations/docs/reference/rest/v1beta/projects.locations.workstationClusters.workstationConfigs.workstations'
+    parameters:
+      - !ruby/object:Api::Type::String
+        name: "workstationClusterId"
+        input: true
+        required: true
+        url_param_only: true
+        description: |
+          The name of the Workstation Cluster this Workstation's Config is associated with.
+      - !ruby/object:Api::Type::String
+        name: "workstationConfigId"
+        input: true
+        required: true
+        url_param_only: true
+        description: |
+          The name of the Workstation Config this Workstation is associated with.
+      - !ruby/object:Api::Type::String
+        name: 'location'
+        description: 'The [Cloud Workstation location](https://cloud.google.com/workstations/docs/locations) for the workstation.'
+        input: true
+        url_param_only: true
+    properties:
+      - !ruby/object:Api::Type::String
+        name: 'name'
+        description: |
+          Full name of this resource.
+        input: true
+        required: true
+      - !ruby/object:Api::Type::String
+        name: 'displayName'
+        description: |
+          Human-readable name for this resource.
+        input: true
+        required: true
+      - !ruby/object:Api::Type::String
+        name: 'uid'
+        description: |
+          Output only. A system-assigned unique identified for this resource.
+        output: true
+      - !ruby/object:Api::Type::Boolean
+        name: 'reconciling'
+        description: |
+          Output only. Indicates whether this resource is currently being updated to match its intended state.
+        output: true
+      - !ruby/object:Api::Type::KeyValuePairs
+        name: 'annotations'
+        description: |
+          Client-specified annotations.
+      - !ruby/object:Api::Type::KeyValuePairs
+        name: 'labels'
+        description: |
+          Client-specified labels that are applied to the resource and that are also propagated to the underlying 
+          Compute Engine resources.
+      - !ruby/object:Api::Type::String
+        name: 'createTime'
+        description: |
+          Output only. Time when this resource was created.
+        output: true
+      - !ruby/object:Api::Type::String
+        name: 'updateTime'
+        description: |
+          Output only. Time when this resource was most recently updated.
+        output: true
+      - !ruby/object:Api::Type::String
+        name: 'deleteTime'
+        description: |
+          Output only. Time when this resource was soft-deleted.
+        output: true
+      - !ruby/object:Api::Type::String
+        name: 'etag'
+        description: |
+          Checksum computed by the server. 
+          May be sent on update and delete requests to ensure that the client has an up-to-date value before proceeding.
+      - !ruby/object:Api::Type::Enum
+        name: 'state'
+        description: |
+          Output only. Current state of the workstation.
+        output: true
+        values:
+          - :STATE_UNSPECIFIED
+          - :STATE_STARTING
+          - :STATE_RUNNING  
+          - :STATE_STOPPING 
+          - :STATE_STOPPED 
+      - !ruby/object:Api::Type::String
+        name: 'host'
+        description: |
+          Output only. Host to which clients can send HTTPS traffic that will be received by the workstation. 
+          Authorized traffic will be received to the workstation as HTTP on port 80. To send traffic to a different port, 
+          clients may prefix the host with the destination port in the format "{port}-{host}".
+      
+  
   

--- a/mmv1/products/cloudworkstations/terraform.yaml
+++ b/mmv1/products/cloudworkstations/terraform.yaml
@@ -18,6 +18,40 @@ overrides: !ruby/object:Overrides::ResourceOverrides
     id_format: projects/{{project}}/locations/{{location}}//workstationClusters/{{name}}
     base_url: projects/{{project}}/locations/{{location}}/workstationClusters
     import_format: ["projects/{{project}}/locations/{{location}}/workstationClusters/{{name}}"]
+    examples:
+      - !ruby/object:Provider::Terraform::Examples
+        name: "cloud_workstation_cluster_basic"
+        primary_resource_id: "basic_cluster"
+        primary_resource_name: "fmt.Sprintf(\"tf-test-my-instance%s\", context[\"random_suffix\"])"
+        vars:
+          cluster_name: "my-cluster"
+      - !ruby/object:Provider::Terraform::Examples
+        name: "cloud_workstation_cluster_full"
+        primary_resource_id: "full_cluster"
+        primary_resource_name: "fmt.Sprintf(\"tf-test-my-instance%s\", context[\"random_suffix\"])"
+        vars:
+          cluster_name: "my-cluster"
+      - !ruby/object:Provider::Terraform::Examples
+        name: "cloud_workstation_config_basic"
+        primary_resource_id: "basic_config"
+        primary_resource_name: "fmt.Sprintf(\"tf-test-my-instance%s\", context[\"random_suffix\"])"
+        vars:
+          cluster_name: "my-cluster"
+          config_name: "my-config"
+      - !ruby/object:Provider::Terraform::Examples
+        name: "cloud_workstation_config_full"
+        primary_resource_id: "full_config"
+        primary_resource_name: "fmt.Sprintf(\"tf-test-my-instance%s\", context[\"random_suffix\"])"
+        vars:
+          cluster_name: "my-cluster"
+          config_name: "my-config"
+      - !ruby/object:Provider::Terraform::Examples
+        name: "cloud_workstation_config_workstations"
+        primary_resource_id: "example_workstation"
+        primary_resource_name: "fmt.Sprintf(\"tf-test-my-instance%s\", context[\"random_suffix\"])"
+        vars:
+          cluster_name: "my-cluster"
+          config_name: "my-config"
     properties:
       etag: !ruby/object:Overrides::Terraform::PropertyOverride
         default_from_api: true
@@ -26,6 +60,7 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         description: |
           Output only. Status conditions describing the current resource state.
         default_from_api: true
+
 # This is for copying files over
 files: !ruby/object:Provider::Config::Files
   # These files have templating (ERB) code that will be run.

--- a/mmv1/templates/terraform/examples/cloud_workstation_workstations.tf.erb
+++ b/mmv1/templates/terraform/examples/cloud_workstation_workstations.tf.erb
@@ -1,0 +1,42 @@
+resource "google_cloud_workstations_workstation_clusters" "<%= ctx[:primary_resource_id] %>" {
+  provider  = google-beta
+  location  = "us-central1"
+  name  = "<%= ctx[:vars]['cluster_name'] %>"
+  network = google_compute_network.network.id
+  subnetwork  = google_compute_subnetwork.subnetwork.id
+}
+
+resource "google_cloud_workstations_workstation_configs" "<%= ctx[:primary_resource_id] %>"{
+	provider = google-beta
+	location = "us-central1"
+	name = "<%= ctx[:vars]['config_name'] %>"
+	workstation_cluster_id 	= "<%= ctx[:vars]['cluster_name'] %>"
+}
+
+resource "google_cloud_workstations_workstations" "<%= ctx[:primary_resource_id] %>" {
+	provider = google-beta
+	location = "us-central1"
+	name = "testworkstationnamemin"
+	workstation_cluster_id = "<%= ctx[:vars]['config_name'] %>"
+	workstation_config_id = "<%= ctx[:vars]['cluster_name'] %>"
+	labels = {
+		testlabel = "testlabelvalue"
+	}
+	annotations = {
+		testannotation = "testannotationvalue"
+	}
+}
+
+resource "google_compute_network" "network" {
+  provider                	= google-beta
+  name                    	= "<%= ctx[:vars]['cluster_name'] %>"
+  auto_create_subnetworks 	= false
+}
+
+resource "google_compute_subnetwork" "subnetwork" {
+  provider      = google-beta
+  name          = "<%= ctx[:vars]['cluster_name'] %>"
+  ip_cidr_range = "10.0.0.0/24"
+  region        = "us-central1"
+  network       = google_compute_network.network.name
+}


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
Adds support for the Workstations resource within Cloud Workstations.

Based on https://github.com/NickElliot/magic-modules/pull/2


<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-the-terraform-providers), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [ ] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:new-resource
Add support for Cloud Workstations
```
